### PR TITLE
Add all available language checkpoints from huggingface.co

### DIFF
--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/ar.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/ar.conf
@@ -1,0 +1,16 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="ar"
+
+# Low quality male voice
+DEFAULT_M_LOW_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/ar/ar_JO/kareem/low/epoch%3D4509-step%3D805030.ckpt?download=true
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/ar/ar_JO/kareem/medium/epoch%3D5079-step%3D1682020.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/ca.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/ca.conf
@@ -1,0 +1,13 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="ca"
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/ca/ca_ES/upc_ona/medium/epoch%3D3184-step%3D1641140.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/cs.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/cs.conf
@@ -1,0 +1,16 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="cs"
+
+# Low quality male voice
+DEFAULT_M_LOW_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/cs/cs_CZ/jirka/low/epoch%3D9119-step%3D1294098.ckpt?download=true
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/cs/cs_CZ/jirka/medium/epoch%3D8819-step%3D1435400.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/da.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/da.conf
@@ -1,0 +1,13 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="da"
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/da/da_DK/talesyntese/medium/epoch%3D3264-step%3D1634940.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/de.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/de.conf
@@ -1,0 +1,22 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="de"
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/de/de_DE/mls/medium/epoch%3D128-step%3D5149698.ckpt?download=true
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/de/de_DE/thorsten/medium/epoch%3D3135-step%3D2702056.ckpt?download=true
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/de/de_DE/thorsten_emotional/medium/epoch%3D6069-step%3D230660.ckpt?download=true
+
+# High quality male voice
+DEFAULT_M_HIGH_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/de/de_DE/thorsten/high/epoch%3D2665-step%3D1182078.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/en-gb.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/en-gb.conf
@@ -1,0 +1,40 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="en-gb"
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_GB/alan/medium/epoch%3D6339-step%3D1647790.ckpt?download=true
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_GB/northern_english_male/medium/epoch%3D9029-step%3D2261720.ckpt?download=true
+
+
+
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_GB/alba/medium/epoch%3D4179-step%3D2101090.ckpt?download=true
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_GB/aru/medium/epoch%3D3479-step%3D939600.ckpt?download=true
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_GB/cori/medium/cori-med-640.ckpt?download=true
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_GB/jenny_dioco/medium/epoch%3D2748-step%3D1729300.ckpt?download=true
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_GB/semaine/medium/epoch%3D1849-step%3D214600.ckpt?download=true
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_GB/vctk/medium/epoch%3D545-step%3D1511328.ckpt?download=true
+
+# High quality female voice
+DEFAULT_F_HIGH_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_GB/cori/high/cori-high-500.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/en-us.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/en-us.conf
@@ -1,27 +1,64 @@
 # URLS for default checkpoint files
 # please name this file with the language codes used by espeak-ng where possible
 
-# An espeak-ng language code is required by piper to preprocess the dataset.  
+# An espeak-ng language code is required by piper to preprocess the dataset.
 # (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
 ESPEAK_LANGUAGE="en-us"
 
-# You will find links to pretrained checkpoints in many languages at:  https://huggingface.co/datasets/rhasspy/piper-checkpoints/tree/main
-
-# Low quality male voice
-DEFAULT_M_LOW_URL="https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/lessac/low/epoch%3D2307-step%3D558536.ckpt?download=true"
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/arctic/medium/epoch%3D663-step%3D646736.ckpt?download=true
 
 # Medium quality male voice
-DEFAULT_M_MED_URL="https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/lessac/medium/epoch%3D2164-step%3D1355540.ckpt?download=true"
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/bryce/medium/bryce-3499.ckpt?download=true
 
-# High quality male voice
-DEFAULT_M_HIGH_URL="https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/lessac/high/epoch%3D2218-step%3D838782.ckpt?download=true"
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/hfc_male/medium/epoch%3D2785-step%3D2128064.ckpt?download=true
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/joe/medium/epoch%3D7889-step%3D1221224.ckpt?download=true
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/john/medium/john-2599.ckpt?download=true
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/kusal/medium/epoch%3D2652-step%3D1953828.ckpt?download=true
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/l2arctic/medium/epoch%3D536-step%3D902160.ckpt?download=true
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/ryan/medium/epoch%3D4641-step%3D3104302.ckpt?download=true
+
+
 
 
 # Low quality female voice
-DEFAULT_F_LOW_URL="https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/lessac/low/epoch%3D2307-step%3D558536.ckpt?download=true" # unfortunately no low quality female models are available.
+DEFAULT_F_LOW_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/lessac/low/epoch%3D2307-step%3D558536.ckpt?download=true
 
 # Medium quality female voice
-DEFAULT_F_MED_URL="https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/amy/medium/epoch%3D6679-step%3D1554200.ckpt?download=true"  # amy_medium
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/amy/medium/epoch%3D6679-step%3D1554200.ckpt?download=true
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/hfc_female/medium/epoch%3D2868-step%3D1575188.ckpt?download=true
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/kristin/medium/kristin-2000.ckpt?download=true
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/lessac/medium/epoch%3D2164-step%3D1355540.ckpt?download=true
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/libritts_r/medium/epoch%3D404-step%3D1887300.ckpt?download=true
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/ljspeech/medium/lj-med_1000.ckpt?download=true
 
 # High quality female voice
-DEFAULT_F_HIGH_URL="https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/ljspeech/high/ljspeech-2000.ckpt?download=true" #ljspeech high
+DEFAULT_F_HIGH_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/lessac/high/epoch%3D2218-step%3D838782.ckpt?download=true
+
+# High quality female voice
+DEFAULT_F_HIGH_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/en/en_US/ljspeech/high/ljspeech-2000.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/es.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/es.conf
@@ -1,0 +1,19 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="es"
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/es/es_ES/davefx/medium/epoch%3D5629-step%3D1605020.ckpt?download=true
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/es/es_ES/sharvard/medium/epoch%3D4899-step%3D215600.ckpt?download=true
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/es/es_MX/ald/medium/epoch%3D9999-step%3D1753600.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/fi.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/fi.conf
@@ -1,0 +1,13 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="fi"
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/fi/fi_FI/harri/medium/epoch%3D3369-step%3D1714630.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/fr.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/fr.conf
@@ -1,0 +1,20 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="fr"
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/fr/fr_FR/mls/medium/epoch%3D317-step%3D3124032.ckpt?download=true
+
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/fr/fr_FR/upmc/medium/epoch%3D2999-step%3D702000.ckpt?download=true
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/fr/fr_FR/siwis/medium/epoch%3D3304-step%3D2050940.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/hu.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/hu.conf
@@ -1,0 +1,20 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="hu"
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/hu/hu_HU/imre/medium/epoch%3D5669-step%3D1607900.ckpt?download=true
+
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/hu/hu_HU/anna/medium/epoch%3D8379-step%3D1504700.ckpt?download=true
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/hu/hu_HU/berta/medium/epoch%3D5249-step%3D1429580.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/ka.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/ka.conf
@@ -1,0 +1,13 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="ka"
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/ka/ka_GE/natia/medium/epoch%3D5239-step%3D1607690.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/lb.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/lb.conf
@@ -1,0 +1,13 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="lb"
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/lb/lb_LU/marylux/medium/epoch%3D4419-step%3D1558490.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/ne.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/ne.conf
@@ -1,0 +1,13 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="ne"
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/ne/ne_NP/google/medium/epoch%3D2829-step%3D367900.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/nl.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/nl.conf
@@ -1,0 +1,17 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="nl"
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/nl/nl_NL/mls/medium/epoch%3D242-step%3D9245178.ckpt?download=true
+
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/nl/nl_BE/nathalie/medium/epoch%3D6119-step%3D1806410.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/no.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/no.conf
@@ -1,0 +1,13 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="no"
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/no/no_NO/talesyntese/medium/epoch%3D3459-step%3D2052250.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/pl.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/pl.conf
@@ -1,0 +1,20 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="pl"
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/pl/pl_PL/darkman/medium/epoch%3D4909-step%3D1454360.ckpt?download=true
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/pl/pl_PL/mc_speech/medium/epoch%3D2531-step%3D1906774.ckpt?download=true
+
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/pl/pl_PL/gosia/medium/epoch%3D5001-step%3D1457672.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/pt-br.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/pt-br.conf
@@ -1,0 +1,13 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="pt-br"
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/pt/pt_BR/faber/medium/epoch%3D6159-step%3D1230728.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/pt.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/pt.conf
@@ -1,0 +1,13 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="pt"
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/pt/pt_PT/tug%C3%A3o/medium/epoch%3D5489-step%3D1548390.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/ro.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/ro.conf
@@ -1,0 +1,13 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="ro"
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/ro/ro_RO/mihai/medium/epoch%3D7809-step%3D1558760.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/ru.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/ru.conf
@@ -1,0 +1,23 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="ru"
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/ru/ru_RU/denis/medium/epoch%3D4474-step%3D1521860.ckpt?download=true
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/ru/ru_RU/dmitri/medium/epoch%3D5589-step%3D1478840.ckpt?download=true
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/ru/ru_RU/ruslan/medium/epoch%3D2436-step%3D1724372.ckpt?download=true
+
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/ru/ru_RU/irina/medium/epoch%3D4139-step%3D929464.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/sk.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/sk.conf
@@ -1,0 +1,13 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="sk"
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/sk/sk_SK/lili/medium/epoch%3D9999-step%3D1919660.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/sr.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/sr.conf
@@ -1,0 +1,13 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="sr"
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/sr/sr_RS/serbski_institut/medium/epoch%3D1899-step%3D178600.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/sw.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/sw.conf
@@ -1,0 +1,13 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="sw"
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/sw/sw_CD/lanfrica/medium/epoch%3D2619-step%3D1635820.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/tr.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/tr.conf
@@ -1,0 +1,16 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="tr"
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/tr/tr_TR/dfki/medium/epoch%3D5679-step%3D1489110.ckpt?download=true
+
+# Medium quality male voice
+DEFAULT_M_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/tr/tr_TR/fahrettin/medium/epoch%3D8099-step%3D1497980.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/uk.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/uk.conf
@@ -1,0 +1,13 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="uk"
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/uk/uk_UA/ukrainian_tts/medium/epoch%3D2090-step%3D1166778.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/vi.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/vi.conf
@@ -1,0 +1,13 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="vi"
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/vi/vi_VN/vais1000/medium/epoch%3D4769-step%3D919580.ckpt?download=true

--- a/tts_dojo/PRETRAINED_CHECKPOINTS/languages/zh.conf
+++ b/tts_dojo/PRETRAINED_CHECKPOINTS/languages/zh.conf
@@ -1,0 +1,13 @@
+# URLS for default checkpoint files
+# please name this file with the language codes used by espeak-ng where possible
+
+# An espeak-ng language code is required by piper to preprocess the dataset.
+# (run "espeak-ng --voices" to get a list of supported codes)
+
+# Listen to the voice sample here: https://rhasspy.github.io/piper-samples/
+
+# The user should comment out redundant URLs after picking the voice they prefer, otherwise, the last URL in the list will be used
+ESPEAK_LANGUAGE="zh"
+
+# Medium quality female voice
+DEFAULT_F_MED_URL=https://huggingface.co/datasets/rhasspy/piper-checkpoints/resolve/main/zh/zh_CN/huayan/medium/epoch%3D3269-step%3D2460540.ckpt?download=true


### PR DESCRIPTION
Checkpoint files seem to be incomplete in the huggingface repo - maybe there are more to be found elsewhere?

Let me know and I can see if I can add them (rhasspy.github.io/piper-samples seem to have a lot more voices from all over the place, probably they didn't come with checkpoint files).