### PR TITLE
Fix next_epoch_to_save Not Updating Immediately on Interval Change

### DIFF
--- a/tts_dojo/DOJO_CONTENTS/scripts/utils/checkpoint_grabber.sh
+++ b/tts_dojo/DOJO_CONTENTS/scripts/utils/checkpoint_grabber.sh
@@ -261,6 +261,7 @@ increase_interval(){
 # increases time between saving checkpoint files
    auto_save_rate=$((auto_save_rate + 1))
    checkpoints_until_save=$auto_save_rate
+   next_epoch_to_save=$((last_epoch_seen + auto_save_rate * PIPER_STEP))
 }
 
 
@@ -269,12 +270,13 @@ decrease_interval(){
    if [ "$auto_save_rate" -ge 2 ]; then
        auto_save_rate=$((auto_save_rate - 1))
        checkpoints_until_save=$auto_save_rate
+       next_epoch_to_save=$((last_epoch_seen + auto_save_rate * PIPER_STEP))
    fi
 }
 
 toggle_checkpoint_saving(){
 # turns automatic saving of checkpoints on and off
-   if [ "$auto_save_status" = "ON" ]; then 
+   if [ "$auto_save_status" = "ON" ]; then
        auto_save_status="OFF"
    else
        auto_save_status="ON"


### PR DESCRIPTION
This PR fixes an issue where next_epoch_to_save was not updated immediately when changing the save interval (increase_interval or decrease_interval).

Previously, next_epoch_to_save would remain based on the old interval until the next checkpoint was processed.
If the interval was decreased, saved checkpoints would still follow the old interval, causing unnecessary delays. Similarly, if training was stopped before reaching the incorrect next_epoch_to_save, resuming would lose all intermediate progress that should have been saved earlier.