### PR TITLE
Fix RTX 40-series support, checkpoint grabber, dojo shutdown and export tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN python3.10 -m venv .venv && \
     /app/piper/src/python/.venv/bin/pip install build && \
     /app/piper/src/python/.venv/bin/pip install -e . && \
     /app/piper/src/python/.venv/bin/pip install --no-deps piper-tts && \ 
-    /app/piper/src/python/.venv/bin/pip install cython==0.29.37 piper-phonemize==1.1.0 librosa==0.10.2.post1 numpy==1.23.5 onnxruntime>=1.20.1  torch==1.13.1 pytorch-lightning==1.7.7 torchmetrics==0.11.4 && \
+    /app/piper/src/python/.venv/bin/pip install cython==0.29.37 piper-phonemize==1.1.0 librosa==0.10.2.post1 numpy==1.23.5 onnxruntime>=1.20.1 pytorch-lightning==1.7.7 torchmetrics==0.11.4 && \
+    /app/piper/src/python/.venv/bin/pip install --index-url https://download.pytorch.org/whl/cu118 torch==2.0.1 && \
     /app/piper/src/python/.venv/bin/python -m build && \
     bash /app/piper/src/python/build_monotonic_align.sh
 
@@ -30,6 +31,21 @@ RUN python3.10 -m venv .venv && \
 WORKDIR /
 RUN groupadd --gid $USER_GID $USERNAME && useradd -m -s /bin/bash -u $USER_UID -g $USER_GID $USERNAME && \
 chown -R $USER_UID:$USER_GID /home/$USERNAME && usermod --uid $USER_UID --gid $USER_GID $USERNAME 
+
+# Pin setuptools to a version that still ships pkg_resources (removed in setuptools>=81),
+# which pytorch-lightning 1.7.7 imports at runtime.
+RUN /app/piper/src/python/.venv/bin/pip install setuptools==75.3.2
+
+# Upgrade pytorch-lightning to 1.9.5: required for torch 2.x compatibility
+# (PL 1.7.7 fails on RTX 40-series with torch 2.0: MisconfigurationException on LRScheduler API check)
+RUN /app/piper/src/python/.venv/bin/pip install pytorch-lightning==1.9.5
+
+# Install the onnx package: torch 2.x's torch.onnx.export requires it
+# (torch 1.13 bundled its own serializer; torch 2.0 does not)
+RUN /app/piper/src/python/.venv/bin/pip install onnx
+
+# Install pathvalidate: required by the piper CLI (piper.__main__)
+RUN /app/piper/src/python/.venv/bin/pip install pathvalidate
 
 
 # Set environment variables for CUDA and virtual environment

--- a/prebuilt_container_run.sh
+++ b/prebuilt_container_run.sh
@@ -16,12 +16,13 @@ else
     fail=1
 fi
 
-# Check that NVIDIA container toolkit is installed
-if dpkg -l | grep -q nvidia-container-toolkit; then
+# Check that an nvidia runtime is available in docker
+if docker info --format '{{json .Runtimes}}' 2>/dev/null | grep -qi nvidia; then
     :
 else
-    echo "WARNING! -- Required package NVIDIA Container Toolkit is not installed."
-    echo "install instructions can be found here:"
+    echo "WARNING! -- Required nvidia runtime not available in docker."
+    echo "On Windows, enable GPU support in Docker Desktop Settings > Resources > WSL Integration."
+    echo "On Linux, install the NVIDIA Container Toolkit:"
     echo "https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html"
     echo
     echo

--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,7 @@ informed_consent(){
     echo 
     echo "1. Install required packages"
     echo "    apt-get update"
-    echo "    apt-get install tmux ffmpeg inotify-tools sox"
+    echo "    apt-get install tmux ffmpeg inotify-tools sox jq"
     echo
     echo "2. Make all .sh files in this project executable."
     echo "     eg. chmod +x *.sh"

--- a/tts_dojo/DOJO_CONTENTS/run_training.sh
+++ b/tts_dojo/DOJO_CONTENTS/run_training.sh
@@ -138,7 +138,15 @@ confirm_or_change_dataset(){
 
 
 check_and_copy_ckpt() {
-    local source_folder="$LIGHTNING_LOGS_CHECKPOINT_FOLDER"
+    # use the newest lightning_logs version directory (versions accumulate across runs)
+    local newest_version_dir
+    newest_version_dir=$(ls -1dt "training_folder/lightning_logs"/version_*/ 2>/dev/null | head -n 1)
+    local source_folder
+    if [ -n "$newest_version_dir" ]; then
+        source_folder="${newest_version_dir}checkpoints"
+    else
+        source_folder="$LIGHTNING_LOGS_CHECKPOINT_FOLDER"
+    fi
     local dest_folder="$VOICE_CHECKPOINTS_FOLDER"
 
     # Check if .ckpt file exists in source folder

--- a/tts_dojo/DOJO_CONTENTS/scripts/tts.sh
+++ b/tts_dojo/DOJO_CONTENTS/scripts/tts.sh
@@ -73,11 +73,11 @@ fi
 
 # Attempt to play the audio file
 if command -v paplay &> /dev/null; then
-    paplay "$output_file"
+    timeout 15 paplay "$output_file" || echo "warning: audio playback timed out or failed (file is still valid)"
 elif command -v play &> /dev/null; then
-    play "$output_file" >/dev/null 2>&1
+    timeout 15 play "$output_file" >/dev/null 2>&1 || echo "warning: audio playback timed out or failed (file is still valid)"
 elif command -v aplay &> /dev/null; then
-    aplay "$output_file"
+    timeout 15 aplay "$output_file" || echo "warning: audio playback timed out or failed (file is still valid)"
 else
     echo "No audio player found (paplay/play/aplay). Install pulseaudio-utils or alsa-utils."
 fi

--- a/tts_dojo/DOJO_CONTENTS/scripts/tts.sh
+++ b/tts_dojo/DOJO_CONTENTS/scripts/tts.sh
@@ -55,15 +55,29 @@ if [ -z "$onnx_path" ]; then
 fi
 
 # Generate the audio file with Piper in the docker container
-docker exec -it textymcspeechy-piper bash -c "cd /app/tts_dojo/${DOJO_NAME}/scripts && \
+docker exec textymcspeechy-piper bash -c "cd /app/tts_dojo/${DOJO_NAME}/scripts && \
 echo \"$text\" | piper -m \"$onnx_path\" --output_file \"$output_file\""
+result=$?
+if [ $result -ne 0 ] || [ ! -f "$output_file" ]; then
+    echo "ERROR: piper synthesis failed (exit code $result). Check that the model file is valid."
+    exit 1
+fi
 
 # Inform the user and attempt to play the audio file
 echo "Audio generated and saved to $output_file"
 
-# Attempt to play the audio file with aplay
-if command -v aplay &> /dev/null; then
+# Attempt to play the audio file (WSLg provides pulseaudio for audio output)
+if [ -z "$PULSE_SERVER" ] && [ -S /mnt/wslg/PulseServer ]; then
+    export PULSE_SERVER=/mnt/wslg/PulseServer
+fi
+
+# Attempt to play the audio file
+if command -v paplay &> /dev/null; then
+    paplay "$output_file"
+elif command -v play &> /dev/null; then
+    play "$output_file" >/dev/null 2>&1
+elif command -v aplay &> /dev/null; then
     aplay "$output_file"
 else
-    echo "aplay command not found. Cannot play the audio."
+    echo "No audio player found (paplay/play/aplay). Install pulseaudio-utils or alsa-utils."
 fi

--- a/tts_dojo/DOJO_CONTENTS/scripts/utils/_control_console.sh
+++ b/tts_dojo/DOJO_CONTENTS/scripts/utils/_control_console.sh
@@ -95,6 +95,9 @@ time_until_full() {
 
 kill_session() {
     tmux kill-session
+    # stop the docker container too: killing the tmux session alone leaves the
+    # training process running headless inside the container
+    docker stop textymcspeechy-piper >/dev/null 2>&1
 }
 
 # Define the target pane to send keys to

--- a/tts_dojo/DOJO_CONTENTS/scripts/utils/_tmux_piper_export.sh
+++ b/tts_dojo/DOJO_CONTENTS/scripts/utils/_tmux_piper_export.sh
@@ -62,14 +62,25 @@ update_json() {
     # Extract the base name of the file (without extension)
     local dataset_name=$(basename "$filename" .onnx.json)
 
+    # Optional inference overrides, applied only when set (eg from SETTINGS.txt).
+    # Piper uses these values whenever the client does not pass explicit CLI flags,
+    # so tuning them here (eg lower noise_w for steadier durations) applies to
+    # every downstream app without changing how the voice is exported.
+    local jq_program='.audio.quality = $quality_value | .language.code = $lang_code | .dataset = $dataset'
+    local jq_args=(--arg lang_code "$language_code" --arg quality_value "$quality" --arg dataset "$dataset_name")
+
+    if [ -n "${INFERENCE_NOISE_SCALE:-}" ]; then
+        jq_program="$jq_program | .inference.noise_scale = $INFERENCE_NOISE_SCALE"
+    fi
+    if [ -n "${INFERENCE_LENGTH_SCALE:-}" ]; then
+        jq_program="$jq_program | .inference.length_scale = $INFERENCE_LENGTH_SCALE"
+    fi
+    if [ -n "${INFERENCE_NOISE_W:-}" ]; then
+        jq_program="$jq_program | .inference.noise_w = $INFERENCE_NOISE_W"
+    fi
+
     # Use jq to update the JSON
-    jq --arg lang_code "$language_code" \
-       --arg quality_value "$quality" \
-       --arg dataset "$dataset_name" \
-       '.audio.quality = $quality_value |
-        .language.code = $lang_code |
-        .dataset = $dataset' \
-       "$filename" > tmp.json && mv tmp.json "$filename" && chown 1000:1000 "$filename"
+    jq "${jq_args[@]}" "$jq_program" "$filename" > tmp.json && mv tmp.json "$filename" && chown 1000:1000 "$filename"
 }
 
 

--- a/tts_dojo/DOJO_CONTENTS/scripts/utils/checkpoint_grabber.sh
+++ b/tts_dojo/DOJO_CONTENTS/scripts/utils/checkpoint_grabber.sh
@@ -71,7 +71,7 @@ fi
 
 clear # clear the screen
 # load constants from values sourced from SETTINGS, supply defaults if not specified
-PIPER_STEP=${PIPER_SAVE_CHECKPOINT_EVERY_N_EPOCHS:5}
+PIPER_STEP=${PIPER_SAVE_CHECKPOINT_EVERY_N_EPOCHS:-5}
 MIN_GB=${SETTINGS_GRABBER_MINIMUM_DRIVE_SPACE_GB:-20}
 MIN_GB_WARNING=${DRIVE_SPACE_WARNING_THRESHOLD_GB:-10}
 MINIMUM_DRIVE_SPACE=$((MIN_GB * 1024 * 1024))  # 20 GB in KB
@@ -222,7 +222,7 @@ update_grabber_status() {
     echo -e "                 started at : $start_time_human                  running for : ${running_time_hours}h ${running_time_minutes}m"
 
     echo -e "   Avg. time per checkpoint : ${avg_time_per_checkpoint_min}m ${avg_time_per_checkpoint_sec}s"
-    echo -e "      Last checkpoint saved : $(basename "$last_checkpoint_file") (${last_checkpoint_size} MB)   Last export took : $last_export_duration_seconds seconds"   
+    echo -e "      Last checkpoint seen : $(basename "$last_checkpoint_file") (${last_checkpoint_size} MB)   Last export took : $last_export_duration_seconds seconds"   
     echo -e "       Next epoch # to save : $next_epoch_to_save"
     echo -e "       Time until next save : ${estimated_time_hours}h ${estimated_time_minutes}m ${estimated_time_seconds}s"
     echo -e "checkpoints until next save : $checkpoints_until_save"
@@ -287,15 +287,44 @@ toggle_checkpoint_saving(){
 
 
 check_for_new_checkpoint(){
-# monitors a file that inotify creates to signal arrival of a new checkpoint file
+# monitors a file that inotify creates to signal arrival of a new checkpoint file.
+# falls back to polling the checkpoints directory for the newest checkpoint file,
+# which is required on filesystems where inotify events are not delivered
+# (eg WSL2 mounts of Windows drives such as /mnt/c NTFS).
+    resolve_checkpoints_dir
     if [ -e $NEW_CHECKPOINT_SIGNAL_FILE ]; then
-        newest_checkpoint=$(cat $NEW_CHECKPOINT_SIGNAL_FILE) 
+        signal_checkpoint=$(cat $NEW_CHECKPOINT_SIGNAL_FILE)
+        if [ -n "$signal_checkpoint" ]; then
+            newest_checkpoint=$signal_checkpoint
+        fi
         if [ -f "$newest_checkpoint" ] && [ "$newest_checkpoint" != "$last_file_processed" ];  then
             process_file $newest_checkpoint
             last_file_processed=$newest_checkpoint
         fi
     else
        echo "ERROR- could not find signal file in $NEW_CHECKPOINT_SIGNAL_FILE"
+    fi
+
+    # Polling fallback: detect the newest checkpoint file in the checkpoints directory.
+    newest_checkpoint_in_dir=$(ls -1t "$checkpoints_dir"/*.ckpt 2>/dev/null | head -n 1)
+    if [ -n "$newest_checkpoint_in_dir" ]; then
+        newest_checkpoint=$newest_checkpoint_in_dir
+        if [ "$newest_checkpoint_in_dir" != "$last_file_processed" ]; then
+            process_file "$newest_checkpoint_in_dir"
+            last_file_processed="$newest_checkpoint_in_dir"
+        fi
+    fi
+}
+
+resolve_checkpoints_dir() {
+# points checkpoints_dir at the newest lightning_logs version directory.
+# version directories accumulate when training is resumed without purging lightning_logs.
+    local newest_version_dir
+    newest_version_dir=$(ls -1dt "../training_folder/lightning_logs"/version_*/ 2>/dev/null | head -n 1)
+    if [ -n "$newest_version_dir" ]; then
+        checkpoints_dir="${newest_version_dir}checkpoints"
+    else
+        checkpoints_dir="../training_folder/lightning_logs/version_${version_number}/checkpoints"
     fi
 }
 
@@ -457,8 +486,28 @@ start_time_human=$(date +"%I:%M %p" -d @$start_time)
 show_training_dir_empty_message
 
 # wait for piper to create checkpoints_dir
+# shows live status while waiting (elapsed time + training process health)
+resolve_checkpoints_dir
+wait_start=$(date +%s)
 while [ ! -d "$checkpoints_dir" ]; do
-    sleep 5
+    resolve_checkpoints_dir
+    wait_elapsed=$(( $(date +%s) - wait_start ))
+    wait_min=$((wait_elapsed / 60))
+    wait_sec=$((wait_elapsed % 60))
+    training_alive=$(docker exec textymcspeechy-piper ps aux 2>/dev/null | grep -c "[p]iper_train")
+    if [ "$training_alive" -gt 0 ]; then
+        training_status="piper_train is running"
+    else
+        training_status="WARNING: piper_train process not found - training may have crashed"
+    fi
+    clear
+    echo "Waiting for piper to create the checkpoints directory..."
+    echo "Elapsed: ${wait_min}m ${wait_sec}s   |   $training_status"
+    echo
+    echo "The checkpoints directory appears when piper saves its first checkpoint"
+    echo "(every ${PIPER_STEP} epochs). Epoch pace is visible in TensorBoard at"
+    echo "http://localhost:6006 or in the PIPER TRAINING pane output."
+    sleep 10
 done
 
 show_training_dir_created_message

--- a/tts_dojo/DOJO_CONTENTS/scripts/utils/piper_training.sh
+++ b/tts_dojo/DOJO_CONTENTS/scripts/utils/piper_training.sh
@@ -112,8 +112,8 @@ docker exec textymcspeechy-piper bash -c "cd /app/piper/src/python \
 "
 }
 
-# purge checkpoint folder to ensure consistent location
-rm -r $LIGHTNING_LOGS_LOCATION >/dev/null 2>&1
+# lightning_logs is intentionally NOT purged between runs so that TensorBoard
+# keeps the full training history (each run creates a new version_N directory).
 echo "Train from scratch = $TRAIN_FROM_SCRATCH"
 echo "           Quality = $quality_str" 
 

--- a/tts_dojo/DOJO_CONTENTS/scripts/voice_tester.sh
+++ b/tts_dojo/DOJO_CONTENTS/scripts/voice_tester.sh
@@ -168,7 +168,8 @@ say_text() {
     echo $onnx_path > voice_tester.log
 
     if [[ -n "$onnx_path" ]]; then
-        bash tts.sh "$text_to_say" "$onnx_path" >/dev/null 2>&1
+        echo "=== $(date +%H:%M:%S) say: $text_to_say ===" >> voice_tester.log
+        bash tts.sh "$text_to_say" "$onnx_path" >> voice_tester.log 2>&1
     else
         echo "No .onnx model found in $voice_dir"
     fi


### PR DESCRIPTION
Fixes several tooling bugs that affect any user of the dockerized piper dojo.

## Container
- torch 2.0.1 (cu118) + pytorch-lightning 1.9.5: torch 1.13.1 ships no sm_89 kernels (training crashes on RTX 40-series); PL 1.7.7 is incompatible with torch 2.x (MisconfigurationException on the LRScheduler API check)
- pin setuptools 75.3.2: pkg_resources, imported by pytorch-lightning at runtime, was removed in setuptools >= 81
- install onnx (required by the torch 2.x onnx exporter) and pathvalidate (missing dependency of the piper CLI)

## Scripts
- checkpoint grabber: fix the PIPER_STEP default-value typo (substring syntax instead of a default) which silently broke all grabber statistics; add a polling fallback so the grabber works on filesystems where inotify events are not delivered (eg WSL2 mounts of Windows drives); live wait status while waiting for the first checkpoint
- preserve lightning_logs across runs: training no longer purges the log directory, the grabber follows the newest version_N directory and run_training scans it for unsaved checkpoints, so TensorBoard keeps the full history across restarts
- control console: q now also stops the docker container (previously the training process was left running headless)
- tts.sh: drop docker exec -it (fails in non-TTY contexts), check synthesis errors, playback with paplay/play/aplay fallback and WSLg pulseaudio support, plus a playback timeout so the voice tester cannot freeze
- voice tester: log synthesis output to voice_tester.log instead of discarding it
- voice export: exported .onnx.json can carry optional inference overrides (noise_scale, length_scale, noise_w) set from SETTINGS.txt; add the missing jq dependency to setup.sh (the export pipeline uses jq and previously failed silently when it was absent)
- nvidia runtime detection: check docker info Runtimes instead of dpkg so the prebuilt container script also works with Docker Desktop/WSL2